### PR TITLE
Improve support for multibyte strings

### DIFF
--- a/src/ForceUTF8/Encoding.php
+++ b/src/ForceUTF8/Encoding.php
@@ -324,11 +324,14 @@ class Encoding {
   protected static function utf8_decode($text, $option = self::WITHOUT_ICONV)
   {
     if ($option == self::WITHOUT_ICONV || !function_exists('iconv')) {
-       $o = utf8_decode(
-         str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), self::toUTF8($text))
-       );
+      $utf8 = str_replace(array_keys(self::$utf8ToWin1252), array_values(self::$utf8ToWin1252), self::toUTF8($text));
+      if (function_exists('mb_convert_encoding')) {
+        $o = mb_convert_encoding($utf8, 'Windows-1252', 'UTF-8');
+      } else {
+        $o = utf8_decode($utf8);
+      }
     } else {
-       $o = iconv("UTF-8", "Windows-1252" . ($option === self::ICONV_TRANSLIT ? '//TRANSLIT' : ($option === self::ICONV_IGNORE ? '//IGNORE' : '')), $text);
+      $o = iconv("UTF-8", "Windows-1252" . ($option === self::ICONV_TRANSLIT ? '//TRANSLIT' : ($option === self::ICONV_IGNORE ? '//IGNORE' : '')), $text);
     }
     return $o;
   }


### PR DESCRIPTION
As of PHP 8.2, `utf8_decode` has been deprecated and relying on it is highly discouraged.

For this reason, `utf8_decode` is only used as a last resort, preferring `mb_convert_encoding` when available.